### PR TITLE
Support no_std environments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,8 @@
 //! }
 //! ```
 
+#![no_std]
+
 extern crate const_guards_attribute;
 pub use const_guards_attribute::guard;
 


### PR DESCRIPTION
Would you be interested in supporting `no_std` environments by default?
Or do you have plans for this crate that would require otherwise?
If not, this is the only change required.
Thank you for considering it.